### PR TITLE
Fix unsafe inline - CSP 3.0 compliance

### DIFF
--- a/coins.php
+++ b/coins.php
@@ -34,11 +34,11 @@ if(!isset($_SESSION['UserData']['Username'])) {
 <body>
 
 <div class="tabmenu">
-    <button class="tablinks" onclick="openTabContent(event, 'Summary')" id="defaultOpen">Summary</button>
-    <button class="tablinks" onclick="openTabContent(event, 'Paper Wallet')">Paper Wallet</button>
-    <button class="tablinks" onclick="openTabContent(event, 'Binance')">Binance</button>
-    <button class="tablinks" onclick="openTabContent(event, 'Bitfinex')">Bitfinex</button>
-    <button class="tablinks" onclick="openTabContent(event, 'Watchlist')">Watchlist</button>
+    <button class="tablinks" data-evt="event" data-tab="Summary" id="defaultOpen">Summary</button>
+    <button class="tablinks" data-evt="event" data-tab="Paper Wallet">Paper Wallet</button>
+    <button class="tablinks" data-evt="event" data-tab="Binance">Binance</button>
+    <button class="tablinks" data-evt="event" data-tab="Bitfinex">Bitfinex</button>
+    <button class="tablinks" data-evt="event" data-tab="Watchlist">Watchlist</button>
 </div>
 
 <div id="Summary" class="tabcontent" align="center" style="overflow-x:auto;">
@@ -120,10 +120,6 @@ if(!isset($_SESSION['UserData']['Username'])) {
     <a href="logout.php">Click here</a> to Logout
 </div>
 
-<script>
-    // Get the element with id="defaultOpen" and click on it
-    document.getElementById("defaultOpen").click();
-</script>
 
 </body>
 </html>

--- a/coins.php
+++ b/coins.php
@@ -27,7 +27,6 @@ if(!isset($_SESSION['UserData']['Username'])) {
 <meta name="viewport" content="width=device-width, initial-scale=0.8">
 <title>Cryptocurrency</title>
 <link rel="stylesheet" type="text/css" href="coinstyle.css" />
-<script src="tabs.js"></script>
 </head>
 
 
@@ -119,7 +118,6 @@ if(!isset($_SESSION['UserData']['Username'])) {
 <div class="logout table header green">
     <a href="logout.php">Click here</a> to Logout
 </div>
-
-
+<script src="tabs.js"></script>
 </body>
 </html>

--- a/coins.php
+++ b/coins.php
@@ -33,11 +33,11 @@ if(!isset($_SESSION['UserData']['Username'])) {
 <body>
 
 <div class="tabmenu">
-    <button class="tablinks" data-evt="event" data-tab="Summary" id="defaultOpen">Summary</button>
-    <button class="tablinks" data-evt="event" data-tab="Paper Wallet">Paper Wallet</button>
-    <button class="tablinks" data-evt="event" data-tab="Binance">Binance</button>
-    <button class="tablinks" data-evt="event" data-tab="Bitfinex">Bitfinex</button>
-    <button class="tablinks" data-evt="event" data-tab="Watchlist">Watchlist</button>
+    <button class="tablinks" data-tab="Summary" id="defaultOpen">Summary</button>
+    <button class="tablinks" data-tab="Paper Wallet">Paper Wallet</button>
+    <button class="tablinks" data-tab="Binance">Binance</button>
+    <button class="tablinks" data-tab="Bitfinex">Bitfinex</button>
+    <button class="tablinks" data-tab="Watchlist">Watchlist</button>
 </div>
 
 <div id="Summary" class="tabcontent" align="center" style="overflow-x:auto;">

--- a/tabs.js
+++ b/tabs.js
@@ -19,9 +19,13 @@ function openTabContent(evt, tabID) {
     document.getElementById(tabID).style.display = "block";
     evt.currentTarget.className += " active";
 }
+
+// Add EventListeners so tabs can be clicked; if clicked show the content of that tab
 document.querySelectorAll('.tablinks').forEach(item => {
-          item.addEventListener('click', function(){
-          openTabContent(event,item.dataset.tab);
+    item.addEventListener('click', function(){
+        openTabContent(event,item.dataset.tab);
         });
-  });
+    });
+
+// Get the element with id="defaultOpen" and click on it
 document.getElementById("defaultOpen").click();

--- a/tabs.js
+++ b/tabs.js
@@ -19,3 +19,9 @@ function openTabContent(evt, tabID) {
     document.getElementById(tabID).style.display = "block";
     evt.currentTarget.className += " active";
 }
+document.querySelectorAll('.tablinks').forEach(item => {
+          $(item).click(function() {
+          openTabContent(event,item.dataset.tab);
+        });
+  });
+document.getElementById("defaultOpen").click();

--- a/tabs.js
+++ b/tabs.js
@@ -20,7 +20,7 @@ function openTabContent(evt, tabID) {
     evt.currentTarget.className += " active";
 }
 document.querySelectorAll('.tablinks').forEach(item => {
-          $(item).click(function() {
+          item.addEventListener('click', function(){
           openTabContent(event,item.dataset.tab);
         });
   });


### PR DESCRIPTION
Hi mate! 

I just noticed you used the same bit of javascript snippet I iterated from when doing tabs on some of my own stuff.

Unfortunatly, inline javascript, like the bit at the bottom, or the onclick() events, aren't a great thing when it comes to security.

With that little change on the javascript and html, you get around the issue, and it won't bump against Content Security Policies in PHP headers.

Instead of the HTML launching the event, the javascript will query the tablinks

Keep up the good work!